### PR TITLE
modified to handle the case where nmap does not output a service for the port at all

### DIFF
--- a/xml2csv.py
+++ b/xml2csv.py
@@ -71,7 +71,10 @@ def get_host_data(root):
                 
                 proto = port.attrib['protocol']
                 port_id = port.attrib['portid']
-                service = port.findall('service')[0].attrib['name']
+                try:
+                    service = port.findall('service')[0].attrib['name']
+                except (IndexError, KeyError):
+                    service = ''
                 try:
                     product = port.findall('service')[0].attrib['product']
                 except (IndexError, KeyError):


### PR DESCRIPTION
Allows the script to continue in cases where nmap does not provide a service in the xml output for a given port like in the example xml below

```
<host starttime="1645128783" endtime="1645129225"><status state="up" reason="echo-reply" reason_ttl="114"/>
<address addr="x.x.x.x" addrtype="ipv4"/>
<hostnames>
<hostname name="xxxx" type="PTR"/>
</hostnames>
<ports><extraports state="filtered" count="65472">
<extrareasons reason="no-responses" count="65472"/>
</extraports>
<port protocol="tcp" portid="25"><state state="open" reason="syn-ack" reason_ttl="120"/><service name="smtp" method="table" conf="3"/></port>
<port protocol="tcp" portid="43"><state state="open" reason="syn-ack" reason_ttl="119"/><service name="whois" method="table" conf="3"/></port>
<port protocol="tcp" portid="80"><state state="open" reason="syn-ack" reason_ttl="56"/><service name="http" method="table" conf="3"/></port>
<port protocol="tcp" portid="5900"><state state="open" reason="syn-ack" reason_ttl="119"/><service name="vnc" method="table" conf="3"/></port>
<port protocol="tcp" portid="5901"><state state="open" reason="syn-ack" reason_ttl="56"/><service name="vnc-1" method="table" conf="3"/></port>
<port protocol="tcp" portid="6379"><state state="open" reason="syn-ack" reason_ttl="120"/><service name="redis" method="table" conf="3"/></port>
<port protocol="tcp" portid="8062"><state state="open" reason="syn-ack" reason_ttl="119"/></port>
<port protocol="tcp" portid="8063"><state state="open" reason="syn-ack" reason_ttl="120"/></port>
<port protocol="tcp" portid="8075"><state state="open" reason="syn-ack" reason_ttl="120"/></port>
<port protocol="tcp" portid="8080"><state state="open" reason="syn-ack" reason_ttl="56"/><service name="http-proxy" method="table" conf="3"/></port>
<port protocol="tcp" portid="8081"><state state="open" reason="syn-ack" reason_ttl="56"/><service name="blackice-icecap" method="table" conf="3"/></port>
```